### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ include_recipe 'stunnel'
 stunnel_connection 'random_service' do
   connect "#{rnd_srv_node[:ipaddress]}:#{rnd_srv_node[:random_service][:port]}"
   accept node[:random_service][:local_accept_port]
-  notifies :restart, 'service[stunnel]'
+  notifies :reload, 'service[stunnel]'
 end
 ```
 
@@ -22,7 +22,7 @@ include_recipe 'stunnel::server'
 stunnel_connection 'random_service' do
   accept node[:random_service][:tunnel_port]
   connect node[:random_service][:port]
-  notifies :restart, 'service[stunnel]'
+  notifies :reload, 'service[stunnel]'
 end
 ```
 


### PR DESCRIPTION
With notifies :restart in the call to the LWRP, chef-client seems to restart the stunnel processes on every run, rather than when there are changes. :reload seems to at least avoid the few second delay the (ubuntu) init script has on restart. Furthermore it seems like if I change the call to the LWRP (even with :reload), chef-client restarts the daemon anyway. But that's preferable since there's an actual change.
