### PR TITLE
Make the config Chef 11 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ default[:stunnel][:packages] = %w(stunnel4)
 default[:stunnel][:service_name] = 'stunnel4'
 
 default[:stunnel][:ssl_dir] = '/etc/ssl'
-default[:stunnel][:server_ssl_req]  = "/C=US/ST=Several/L=Locality/O=Example/OU=Operations/CN=#{node.fqdn}/emailAddress=root@#{node.fqdn}"
+default[:stunnel][:server_ssl_req]  = "/C=US/ST=Several/L=Locality/O=Example/OU=Operations/CN=#{node[:fqdn]}/emailAddress=root@#{node[:fqdn]}"
 default[:stunnel][:cert_fqdn] = node[:fqdn]
 
 default[:stunnel][:use_chroot] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@ end
 
 default[:stunnel][:service_name] = 'stunnel4'
 default[:stunnel][:ssl_dir] = '/etc/ssl'
-default[:stunnel][:server_ssl_req]  = "/C=US/ST=Several/L=Locality/O=Example/OU=Operations/CN=#{node.fqdn}/emailAddress=root@#{node.fqdn}"
+default[:stunnel][:server_ssl_req]  = "/C=US/ST=Several/L=Locality/O=Example/OU=Operations/CN=#{node[:fqdn]}/emailAddress=root@#{node[:fqdn]}"
 default[:stunnel][:cert_fqdn] = node[:fqdn]
 
 default[:stunnel][:use_chroot] = false


### PR DESCRIPTION
The `node.fqdn` call needed to be replaced with `node[:fqdn]`
