### PR TITLE
Multiple client/server stunnels on same node. Updated provider

### DIFF
--- a/providers/connection.rb
+++ b/providers/connection.rb
@@ -6,10 +6,12 @@ def load_current_resource
 end
 
 action :create do
+  client_mode = new_resource.client or node[:stunnel][:client_mode]
   hsh = Mash.new(
     :connect => new_resource.connect,
     :accept => new_resource.accept,
-    :timeout_close => new_resource.timeout_close
+    :timeout_close => new_resource.timeout_close,
+    :client => client_mode
   )
   exist = Mash.new(node[:stunnel][:services][new_resource.service_name])
   if(exist != hsh)

--- a/resources/connection.rb
+++ b/resources/connection.rb
@@ -5,3 +5,4 @@ attribute :service_name, :kind_of => String
 attribute :connect, :required => true
 attribute :accept, :required => true
 attribute :timeout_close, :kind_of => [TrueClass,FalseClass]
+attribute :client, :kind_of => [TrueClass,FalseClass,NilClass], :default => nil

--- a/templates/default/stunnel.conf.erb
+++ b/templates/default/stunnel.conf.erb
@@ -59,11 +59,6 @@ debug = <%= node[:stunnel][:debug] %>
 output = <%= node[:stunnel][:output] %>
 <% end -%>
 
-; SSL client mode
-<% if node[:stunnel][:client_mode] -%>
-client = yes
-<% end -%>
-
 ; service-level configuration
 
 <% if node[:stunnel][:https][:enabled] %>
@@ -78,6 +73,7 @@ TIMEOUTclose = 0
 [<%= name %>]
 accept = <%= opts[:accept] %>
 connect = <%= opts[:connect] %>
+client = <%= opts[:client] ? "yes" : "no" %>
 <% unless opts[:timeout_close].nil? -%>
 TIMEOUTclose = <%= opts[:timeout_close] ? 1 : 0 %>
 <% end -%>


### PR DESCRIPTION
Looking at https://www.stunnel.org/static/stunnel.html shows that "client" (yes/no)
is actually a service configuration attirbute, not a global.

For backward-compatibility with previous versions, I left default[:stunnel][:client_mode]
but that only sets a "default" policy

It is now possible (and recommended) to specify the client mode in the provider definition
allowing multiple, different stunnels on the same node

```
stunnel_connection 'random_service' do
  accept node[:random_service][:tunnel_port]
  connect node[:random_service][:port]
  notifies :restart, 'service[stunnel]'
  client false # or true, if unspecified node[:stunnel][:client_mode] is used
end
```
