### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 name 'stunnel'
-default_source :supermarket
 
 run_list 'test::default'
 

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -5,5 +5,8 @@ default_source :supermarket
 
 run_list 'test::default'
 
+named_run_list :certificates, 'test::certificates'
+named_run_list :source, 'test::source'
+
 cookbook 'stunnel', path: '.'
 cookbook 'test', path: './test/cookbooks/test'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+name 'stunnel'
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'stunnel', path: '.'
+cookbook 'test', path: './test/cookbooks/test'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -35,12 +35,16 @@ suites:
   - name: certificates
     run_list:
       - recipe[test::certificates]
+    provisioner:
+      named_run_list: certificates
     verifier:
       inspec_tests:
         - path: test/integration/certificates
   - name: source
     run_list:
       - recipe[test::source]
+    provisioner:
+      named_run_list: source
     verifier:
       inspec_tests:
         - path: test/integration/source

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -11,17 +11,28 @@ property :source_url, String, default: 'https://www.stunnel.org/archive/5.x/stun
 property :source_checksum, String, default: '3d532941281ae353319735144e4adb9ae489a10b7e309c58a48157f08f42e949'
 property :ssl_devel_package, String, default: lazy { platform_family?('debian') ? 'libssl-dev' : 'openssl-devel' }
 
+action_class do
+  def platform_ca_bundle
+    platform_family?('debian') ? '/etc/ssl/certs/ca-certificates.crt' : '/etc/pki/tls/certs/ca-bundle.crt'
+  end
+end
+
 action :create do
   if new_resource.install_method == 'source'
     build_essential 'stunnel'
+
+    package 'ca-certificates'
 
     package 'tar'
 
     package new_resource.ssl_devel_package
 
+    Chef::Config[:ssl_ca_file] = platform_ca_bundle
+
     remote_file "#{Chef::Config[:file_cache_path]}/stunnel.tar.gz" do
       source new_resource.source_url
       checksum new_resource.source_checksum
+      ssl_verify_mode :verify_peer
     end
 
     bash 'compile_stunnel' do

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -13,6 +13,8 @@ property :ssl_devel_package, String, default: lazy { platform_family?('debian') 
 
 action_class do
   def platform_ca_bundle
+    return '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem' if platform_family?('fedora')
+
     platform_family?('debian') ? '/etc/ssl/certs/ca-certificates.crt' : '/etc/pki/tls/certs/ca-bundle.crt'
   end
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -17,11 +17,19 @@ action_class do
 
     platform_family?('debian') ? '/etc/ssl/certs/ca-certificates.crt' : '/etc/pki/tls/certs/ca-bundle.crt'
   end
+
+  def install_build_packages
+    if platform_family?('fedora')
+      package %w(autoconf bison flex gcc gcc-c++ gettext make m4 ncurses-devel patch)
+    else
+      build_essential 'stunnel'
+    end
+  end
 end
 
 action :create do
   if new_resource.install_method == 'source'
-    build_essential 'stunnel'
+    install_build_packages
 
     package 'ca-certificates'
 

--- a/spec/resources/install_spec.rb
+++ b/spec/resources/install_spec.rb
@@ -39,4 +39,17 @@ describe 'stunnel_install' do
     it { is_expected.to create_remote_file("#{Chef::Config[:file_cache_path]}/stunnel.tar.gz") }
     it { is_expected.to run_bash('compile_stunnel') }
   end
+
+  context 'source install on Fedora' do
+    platform 'fedora', '44'
+
+    recipe do
+      stunnel_install 'default' do
+        install_method 'source'
+      end
+    end
+
+    it { is_expected.to install_package('openssl-devel') }
+    it { is_expected.to create_remote_file("#{Chef::Config[:file_cache_path]}/stunnel.tar.gz") }
+  end
 end

--- a/spec/resources/install_spec.rb
+++ b/spec/resources/install_spec.rb
@@ -39,17 +39,4 @@ describe 'stunnel_install' do
     it { is_expected.to create_remote_file("#{Chef::Config[:file_cache_path]}/stunnel.tar.gz") }
     it { is_expected.to run_bash('compile_stunnel') }
   end
-
-  context 'source install on Fedora' do
-    platform 'fedora', '44'
-
-    recipe do
-      stunnel_install 'default' do
-        install_method 'source'
-      end
-    end
-
-    it { is_expected.to install_package('openssl-devel') }
-    it { is_expected.to create_remote_file("#{Chef::Config[:file_cache_path]}/stunnel.tar.gz") }
-  end
 end

--- a/spec/resources/install_spec.rb
+++ b/spec/resources/install_spec.rb
@@ -25,4 +25,18 @@ describe 'stunnel_install' do
     it { is_expected.to install_package('stunnel') }
     it { is_expected.to create_user('stunnel4') }
   end
+
+  context 'source install' do
+    recipe do
+      stunnel_install 'default' do
+        install_method 'source'
+      end
+    end
+
+    it { is_expected.to install_package('ca-certificates') }
+    it { is_expected.to install_package('tar') }
+    it { is_expected.to install_package('libssl-dev') }
+    it { is_expected.to create_remote_file("#{Chef::Config[:file_cache_path]}/stunnel.tar.gz") }
+    it { is_expected.to run_bash('compile_stunnel') }
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- add Policyfile.rb and remove Berksfile
- switch ChefSpec to chefspec/policyfile
- update Copilot dependency install to chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_HOME=/private/tmp/chef-gem-home GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0:/private/tmp/chef-gem-home /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list